### PR TITLE
Fixed the bug when the component label is possibly null

### DIFF
--- a/src/main/java/ui/panels/ScorePanel.java
+++ b/src/main/java/ui/panels/ScorePanel.java
@@ -72,7 +72,11 @@ public class ScorePanel extends JPanel {
     }
 
     public void setLabel(String componentName) {
-        this.label.setText(componentName);
+        System.out.println("comp: "+componentName);
+        if(null != componentName)
+            this.label.setText(componentName);
+        else
+            this.label.setText("Component");
     }
 
     private void setScoreLabel() {


### PR DESCRIPTION
In some cases there is a chance that the label got a null as parameter, thus the repaint in the JLabel removes the label object. Here is the fix what replaces null value with a default "Component" string in these cases.